### PR TITLE
Fix for #8 by setting opponent Pad velocity in Network mode

### DIFF
--- a/lib/ball.dart
+++ b/lib/ball.dart
@@ -133,7 +133,7 @@ class Ball extends PositionComponent with HasGameRef<PaddleGame> {
         gameRef.playPopSound();
         y = gameRef.oppoPad.y + gameRef.oppoPad.height / 2 + 2 * radius;
         _vy = -vy;
-        _vx += randSpin(gameRef.myPad.vx.sign);
+        _vx += randSpin(gameRef.oppoPad.vx.sign);
         forceNetSend = true;
       } else if (y - radius <= gameRef.topMargin && vy < 0) {
         // bounced top

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -305,18 +305,18 @@ class PaddleGame extends FlameGame with HorizontalDragDetector, SingleGameInstan
     final dragX = info.delta.global.x;
     final endX = info.eventPosition.global.x;
     if (endX >= myPad.x - myPad.width / 2 && endX <= myPad.x + myPad.width / 2) {
-      myPad.setPlayerStationary();
+      myPad.setStationary();
     } else if (dragX < 0) {
-      myPad.movePlayerLeft();
+      myPad.moveLeft();
     } else if (dragX > 0) {
-      myPad.movePlayerRight();
+      myPad.moveRight();
     }
   }
 
   /// when end of drag detected, stop moving player's paddle
   @override
   void onHorizontalDragEnd(DragEndInfo info) {
-    myPad.setPlayerStationary();
+    myPad.setStationary();
   }
 
   /// start Single Player game
@@ -418,7 +418,15 @@ class PaddleGame extends FlameGame with HorizontalDragDetector, SingleGameInstan
       }
 
       _receiveCount = data.count;
-      oppoPad.setOpponentPos(_pxMap.toDevX(1.0 - data.px));
+      final newX = _pxMap.toDevX(1.0 - data.px);
+      if (oppoPad.x > newX) {
+        oppoPad.moveLeft();
+      } else if (oppoPad.x < newX) {
+        oppoPad.moveRight();
+      } else {
+        oppoPad.setStationary();
+      }
+      oppoPad.setX(newX);
 
       if (data.by > 0.8 && data.bvy < 0 && ball.vy < 0) {
         // ball Y direction changed, opponent must have detected hit, play Pop

--- a/lib/pad.dart
+++ b/lib/pad.dart
@@ -101,28 +101,20 @@ class Pad extends PositionComponent with HasGameRef<PaddleGame> {
     } // let remote host set opponent position
   }
 
-  void movePlayerLeft() {
-    if (isPlayer) {
-      _vx = -_pxMap.toDevWth(speedNormX);
-    }
+  void moveLeft() {
+    _vx = -_pxMap.toDevWth(speedNormX);
   }
 
-  void movePlayerRight() {
-    if (isPlayer) {
-      _vx = _pxMap.toDevWth(speedNormX);
-    }
+  void moveRight() {
+    _vx = _pxMap.toDevWth(speedNormX);
   }
 
-  void setPlayerStationary() {
-    if (isPlayer) {
-      _vx = 0;
-    }
+  void setStationary() {
+    _vx = 0;
   }
 
-  void setOpponentPos(double oppoPosX) {
-    if (!isPlayer) {
-      x = oppoPosX;
-    }
+  void setX(double newX) {
+    x = newX;
   }
 
   // see if pad touches the normalized rectangle


### PR DESCRIPTION
Fix for #8.

* caught bug in Ball not properly setting opponent Pad velocity
* in network game mode, use opponent's Pad previous and new position to set Pad's velocity
* simply names of Pad calls to set position & velocity removing check to see if player or opponent